### PR TITLE
Underscore should be a standard dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
   },
   "author": "Elliot Foster",
   "license": "MIT",
+  "dependencies": {
+    "underscore": ">= 1.0.0"
+  },
   "devDependencies": {
     "chai": ">=1.0.0",
-    "mocha": ">=1.0.0",
-    "underscore": ">= 1.0.0"
+    "mocha": ">=1.0.0"
   },
   "peerDependencies": {
     "chai": ">= 1.0.0"


### PR DESCRIPTION
Fixes issues where projects that don't explicitly include underscore (perhaps because they use lodash or don't need either) fail to test when chai-fuzzy is pulled in as a dependency (devDependencies are not included in this case).
